### PR TITLE
Access control tweaks, remove Options typealias

### DIFF
--- a/Examples/Scotty-iOSExample/View Controllers/ViewController.swift
+++ b/Examples/Scotty-iOSExample/View Controllers/ViewController.swift
@@ -13,7 +13,7 @@ class ViewController: UIViewController, RouteRespondable {
 
     // MARK: Properties
     var isPreparedForAction: Bool = false
-    var routeAction: RouteAction?
+    var routeAction: RouteRespondable.Action?
 
 	// MARK: Lifecycle
     override func viewDidAppear(_ animated: Bool) {

--- a/Sources/Scotty/Route.swift
+++ b/Sources/Scotty/Route.swift
@@ -9,17 +9,16 @@
 import Foundation
 
 public struct Route<RootViewController: UIViewController> {
-    public typealias Options = [AnyHashable: Any]
-    public typealias Navigator = (_ rootViewController: RootViewController, _ options: Options?) -> Bool
+    public typealias Navigator = (_ rootViewController: RootViewController, _ options: [AnyHashable: Any]?) -> Bool
     
     // MARK: Properties
     private let navigator: Navigator
 
     /// Determines if this Routable object can be suspended by its executing RouteController. If this property is set to false, this route will always execute immediately.
-    let isSuspendable: Bool
+    public let isSuspendable: Bool
     
     /// A unique identifier for this Routable object. Should be unique among all routes an application supports.
-    let identifier: RouteIdentifier
+    public let identifier: RouteIdentifier
     
     // MARK: Initializers
     
@@ -51,7 +50,7 @@ public struct Route<RootViewController: UIViewController> {
     ///   - rootViewController: The view controller at the root of the navigation hierarchy.
     ///   - options: Any routing options that should be taken into account when routing.
     /// - Returns: Return true if the routing is successful, false otherwise.
-    func route(fromRootViewController rootViewController: RootViewController, options: Options?) -> Bool {
+    func route(fromRootViewController rootViewController: RootViewController, options: [AnyHashable: Any]?) -> Bool {
         return navigator(rootViewController, options)
     }
 }

--- a/Sources/Scotty/RouteController.swift
+++ b/Sources/Scotty/RouteController.swift
@@ -35,7 +35,7 @@ public extension RouteController {
 	///   - options: Any routing options that should be taken into account when routing.
 	/// - Returns: Returns true if routing reaches its intended destination, otherwise returns false.
     @discardableResult
-    func open(_ route: Route<RootViewController>?, options: Route<RootViewController>.Options? = nil) -> Bool {
+    func open(_ route: Route<RootViewController>?, options: [AnyHashable: Any]? = nil) -> Bool {
         guard let route = route else { return false }
         guard isPreparedForRouting || !route.isSuspendable else { storedRoute = stored(route: route, options: options); return false }
         return route.route(fromRootViewController: rootViewController, options: options)
@@ -104,7 +104,7 @@ fileprivate extension RouteController {
 // MARK: Route Storage
 fileprivate extension RouteController {
     
-    func stored(route: Route<RootViewController>, options: Route<RootViewController>.Options?) -> () -> Void {
+    func stored(route: Route<RootViewController>, options: [AnyHashable: Any]?) -> () -> Void {
         return { [weak self] in
             self?.open(route, options: options)
         }


### PR DESCRIPTION
- Made 'identifier' and 'isSuspendable' properties of a Route public
- Removed the 'RouteController<X>.Options' typelias - it would often take longer to type than the actual [AnyHashable: Any] type.
- Fixed an issue with the sample app.