### PR TITLE
Remove UIViewController restriction on Root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,7 +115,7 @@
 * Add controllers and protocols to make it simple to handle app routing from many possible input sources. Here's how it works:
 
 ```swift
-let controller = routeController = RouteController(rootViewController: rootVC)
+let controller = routeController = RouteController(root: rootVC)
 controller.open(myRoute)
 ```
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 [Ryan Gant](https://github.com/ganttastic)
 [#29](https://github.com/BottleRocketStudios/iOS-Scotty/pull/29)
 
+* Remove restriction that Route.Root must be a UIViewController.
+[Will McGinty](https://github.com/wmcginty)
+[#30](https://github.com/BottleRocketStudios/iOS-Scotty/pull/30)
+
 ##### Bug Fixes
 
 * None.

--- a/Examples/Scotty-iOSExample/Routing/Routable+App.swift
+++ b/Examples/Scotty-iOSExample/Routing/Routable+App.swift
@@ -16,13 +16,13 @@ extension RouteIdentifier {
 }
 
 // MARK: Define Specialized Routes
-extension Route where RootViewController == UITabBarController {
+extension Route where Root == UITabBarController {
 	    
     static var leftTab: Route {
-		return Route(identifier: .leftTabRoute) { rootViewController, _ -> Bool in
-            rootViewController.selectedIndex = 0
+		return Route(identifier: .leftTabRoute) { root, _ -> Bool in
+            root.selectedIndex = 0
             
-            if let routeRespondableController = rootViewController.selectedViewController as? RouteRespondable {
+            if let routeRespondableController = root.selectedViewController as? RouteRespondable {
                 routeRespondableController.setRouteAction {
                     DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
                         print("LeftTab successfully reached!")
@@ -35,22 +35,22 @@ extension Route where RootViewController == UITabBarController {
     }
     
     static var middleTab: Route {
-        return Route(identifier: .middleTabRoute) { rootViewController, _ -> Bool in
-            rootViewController.selectedIndex = 1
+        return Route(identifier: .middleTabRoute) { root, _ -> Bool in
+            root.selectedIndex = 1
             return true
         }
     }
     
     static var rightTab: Route {
-        return Route(identifier: .rightTabRoute) { rootViewController, _ -> Bool in
-            rootViewController.selectedIndex = 2
+        return Route(identifier: .rightTabRoute) { root, _ -> Bool in
+            root.selectedIndex = 2
             return true
         }
     }
 }
 
 // MARK: Helper
-extension Route where RootViewController == UITabBarController {
+extension Route where Root == UITabBarController {
 	
 	static func route(forIdentifier identifier: String) -> Route? {
 		if identifier.contains(RouteIdentifier.leftTabRoute.rawValue) {

--- a/Examples/Scotty-iOSExample/Routing/RouteController+App.swift
+++ b/Examples/Scotty-iOSExample/Routing/RouteController+App.swift
@@ -15,6 +15,6 @@ class Router {
             fatalError("The application architecture has changed - our root view controller is no longer a UITabBarController. Developer error.")
         }
         
-		return RouteController(rootViewController: rootVC)
+		return RouteController(root: rootVC)
 	}
 }

--- a/README.md
+++ b/README.md
@@ -66,10 +66,10 @@ Creating a new route is as simple as creating a new `Route` instance.
 ``` swift
 extension Route where Root == UITabBarController {
     static var leftTab: Route {
-		return Route(identifier: .leftTabRoute) { rootViewController, options -> Bool in
-            rootViewController.selectedIndex = 0
+		return Route(identifier: .leftTabRoute) { root, options -> Bool in
+            root = 0
 
-            if let routeRespondableController = rootViewController.selectedViewController as? RouteRespondable {
+            if let routeRespondableController = root.selectedViewController as? RouteRespondable {
                 routeRespondableController.setRouteAction {
                     DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
                         print("LeftTab successfully reached!")

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey : Any]?) -> Bool {
         if let window = window, let rootVC = window.rootViewController as? UITabBarController {
-            routeController = RouteController(rootViewController: rootVC)
+            routeController = RouteController(root: rootVC)
         }
 
         return true
@@ -64,7 +64,7 @@ When dealing with URLs, in addition to vending `Route` objects, you will also ne
 Creating a new route is as simple as creating a new `Route` instance.
 
 ``` swift
-extension Route where RootViewController == UITabBarController {
+extension Route where Root == UITabBarController {
     static var leftTab: Route {
 		return Route(identifier: .leftTabRoute) { rootViewController, options -> Bool in
             rootViewController.selectedIndex = 0

--- a/Sources/Scotty/Route.swift
+++ b/Sources/Scotty/Route.swift
@@ -50,8 +50,8 @@ public struct Route<Root> {
     ///   - rootViewController: The view controller at the root of the navigation hierarchy.
     ///   - options: Any routing options that should be taken into account when routing.
     /// - Returns: Return true if the routing is successful, false otherwise.
-    func route(fromRootViewController rootViewController: Root, options: [AnyHashable: Any]?) -> Bool {
-        return navigator(rootViewController, options)
+    func route(fromRoot root: Root, options: [AnyHashable: Any]?) -> Bool {
+        return navigator(root, options)
     }
 }
 

--- a/Sources/Scotty/Route.swift
+++ b/Sources/Scotty/Route.swift
@@ -47,7 +47,7 @@ public struct Route<Root> {
     /// If the intended destination can be reached successfully, this function should return true. Otherwise, return false.
     ///
     /// - Parameters:
-    ///   - root: The view controller at the root of the navigation hierarchy.
+    ///   - root: The object at the root of the navigation hierarchy.
     ///   - options: Any routing options that should be taken into account when routing.
     /// - Returns: Return true if the routing is successful, false otherwise.
     func route(fromRoot root: Root, options: [AnyHashable: Any]?) -> Bool {

--- a/Sources/Scotty/Route.swift
+++ b/Sources/Scotty/Route.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 public struct Route<Root> {
-    public typealias Navigator = (_ rootViewController: Root, _ options: [AnyHashable: Any]?) -> Bool
+    public typealias Navigator = (_ root: Root, _ options: [AnyHashable: Any]?) -> Bool
     
     // MARK: Properties
     private let navigator: Navigator
@@ -47,7 +47,7 @@ public struct Route<Root> {
     /// If the intended destination can be reached successfully, this function should return true. Otherwise, return false.
     ///
     /// - Parameters:
-    ///   - rootViewController: The view controller at the root of the navigation hierarchy.
+    ///   - root: The view controller at the root of the navigation hierarchy.
     ///   - options: Any routing options that should be taken into account when routing.
     /// - Returns: Return true if the routing is successful, false otherwise.
     func route(fromRoot root: Root, options: [AnyHashable: Any]?) -> Bool {

--- a/Sources/Scotty/Route.swift
+++ b/Sources/Scotty/Route.swift
@@ -8,8 +8,8 @@
 
 import Foundation
 
-public struct Route<RootViewController: UIViewController> {
-    public typealias Navigator = (_ rootViewController: RootViewController, _ options: [AnyHashable: Any]?) -> Bool
+public struct Route<Root> {
+    public typealias Navigator = (_ rootViewController: Root, _ options: [AnyHashable: Any]?) -> Bool
     
     // MARK: Properties
     private let navigator: Navigator
@@ -39,7 +39,7 @@ public struct Route<RootViewController: UIViewController> {
     /// - Parameters:
     ///   - route: The route to base the new Route off of.
     ///   - isSuspendable: The suspend ability of this new route. Defaults to true.
-    public init(route: Route<RootViewController>, isSuspendable: Bool = true) {
+    public init(route: Route<Root>, isSuspendable: Bool = true) {
         self.init(identifier: route.identifier, isSuspendable: isSuspendable, navigator: route.navigator)
     }
     
@@ -50,7 +50,7 @@ public struct Route<RootViewController: UIViewController> {
     ///   - rootViewController: The view controller at the root of the navigation hierarchy.
     ///   - options: Any routing options that should be taken into account when routing.
     /// - Returns: Return true if the routing is successful, false otherwise.
-    func route(fromRootViewController rootViewController: RootViewController, options: [AnyHashable: Any]?) -> Bool {
+    func route(fromRootViewController rootViewController: Root, options: [AnyHashable: Any]?) -> Bool {
         return navigator(rootViewController, options)
     }
 }

--- a/Sources/Scotty/RouteController.swift
+++ b/Sources/Scotty/RouteController.swift
@@ -12,13 +12,13 @@ import Foundation
 open class RouteController<Root>: NSObject {
     
     // MARK: Properties
-	fileprivate let rootViewController: Root
+	fileprivate let root: Root
     fileprivate(set) var isPreparedForRouting = false
 	fileprivate(set) var storedRoute: (() -> Void)?
     
     // MARK: Initializers
-    public init(rootViewController: Root, ready: Bool = true) {
-        self.rootViewController = rootViewController
+    public init(root: Root, ready: Bool = true) {
+        self.root = root
         super.init()
         
         setRouteHandling(enabled: ready)
@@ -38,7 +38,7 @@ public extension RouteController {
     func open(_ route: Route<Root>?, options: [AnyHashable: Any]? = nil) -> Bool {
         guard let route = route else { return false }
         guard isPreparedForRouting || !route.isSuspendable else { storedRoute = stored(route: route, options: options); return false }
-        return route.route(fromRootViewController: rootViewController, options: options)
+        return route.route(fromRoot: root, options: options)
     }
 }
 

--- a/Sources/Scotty/RouteController.swift
+++ b/Sources/Scotty/RouteController.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// The RouteController object handles the execution of routes as entry points into your application.
-/// The route controller is generic over its rootViewController (which can be any subclass of UIViewController), meaning that it will only accept routes that begin in the same rootViewController type as it was created with.
+/// The route controller is generic over its root, meaning that it will only accept routes that begin in the same root type as it was created with.
 open class RouteController<Root>: NSObject {
     
     // MARK: Properties

--- a/Sources/Scotty/RouteController.swift
+++ b/Sources/Scotty/RouteController.swift
@@ -9,15 +9,15 @@ import Foundation
 
 /// The RouteController object handles the execution of routes as entry points into your application.
 /// The route controller is generic over its rootViewController (which can be any subclass of UIViewController), meaning that it will only accept routes that begin in the same rootViewController type as it was created with.
-open class RouteController<RootViewController: UIViewController>: NSObject {
+open class RouteController<Root>: NSObject {
     
     // MARK: Properties
-	fileprivate let rootViewController: RootViewController
+	fileprivate let rootViewController: Root
     fileprivate(set) var isPreparedForRouting = false
 	fileprivate(set) var storedRoute: (() -> Void)?
     
     // MARK: Initializers
-    public init(rootViewController: RootViewController, ready: Bool = true) {
+    public init(rootViewController: Root, ready: Bool = true) {
         self.rootViewController = rootViewController
         super.init()
         
@@ -35,7 +35,7 @@ public extension RouteController {
 	///   - options: Any routing options that should be taken into account when routing.
 	/// - Returns: Returns true if routing reaches its intended destination, otherwise returns false.
     @discardableResult
-    func open(_ route: Route<RootViewController>?, options: [AnyHashable: Any]? = nil) -> Bool {
+    func open(_ route: Route<Root>?, options: [AnyHashable: Any]? = nil) -> Bool {
         guard let route = route else { return false }
         guard isPreparedForRouting || !route.isSuspendable else { storedRoute = stored(route: route, options: options); return false }
         return route.route(fromRootViewController: rootViewController, options: options)
@@ -55,7 +55,7 @@ public extension RouteController {
 		case clear
 		case none
 		
-		fileprivate func executePolicy(with routeController: RouteController<RootViewController>) {
+		fileprivate func executePolicy(with routeController: RouteController<Root>) {
 			switch self {
 			case .execute:
 				routeController.executeStoredRoute()
@@ -104,7 +104,7 @@ fileprivate extension RouteController {
 // MARK: Route Storage
 fileprivate extension RouteController {
     
-    func stored(route: Route<RootViewController>, options: [AnyHashable: Any]?) -> () -> Void {
+    func stored(route: Route<Root>, options: [AnyHashable: Any]?) -> () -> Void {
         return { [weak self] in
             self?.open(route, options: options)
         }

--- a/Tests/Tests.swift
+++ b/Tests/Tests.swift
@@ -31,7 +31,7 @@ class Tests: XCTestCase {
 	
 	func testClearOfStoredRoutes() {
 		let routeController = RouteController(rootViewController: UIViewController(), ready: false)
-		let testRoute = Route(identifier: RouteIdentifier(rawValue: "test")) { _, _ in return true }
+		let testRoute = Route<UIViewController>(identifier: RouteIdentifier(rawValue: "test")) { _, _ in return true }
 		routeController.open(testRoute)
 		XCTAssertNotNil(routeController.storedRoute)
 		
@@ -45,7 +45,7 @@ class Tests: XCTestCase {
 	func testAutomaticExecutionOfStoredRoutes() {
 		let exp = expectation(description: "routeExecution")
 		let routeController = RouteController(rootViewController: UIViewController(), ready: false)
-		let testRoute = Route(identifier: RouteIdentifier(rawValue: "test")) { _, _ in
+		let testRoute = Route<UIViewController>(identifier: RouteIdentifier(rawValue: "test")) { _, _ in
 			exp.fulfill()
 			return true
 		}
@@ -72,7 +72,7 @@ class Tests: XCTestCase {
 	func testRouteActionableDestination() {
 		let exp = expectation(description: "routeExecution")
 		let routeController = RouteController(rootViewController: UIViewController())
-		let testRoute = Route(identifier: RouteIdentifier(rawValue: "test")) { _, _ in
+		let testRoute = Route<UIViewController>(identifier: RouteIdentifier(rawValue: "test")) { _, _ in
 			
 			let actionable = ActionableObject()
             actionable.setRouteAction {
@@ -116,7 +116,7 @@ class Tests: XCTestCase {
     }
 	
 	func testNestedAnyRouteInitializers() {
-		let testRoute = Route(identifier: RouteIdentifier(rawValue: "test")) { _, _ in return true }
+		let testRoute = Route<UIViewController>(identifier: RouteIdentifier(rawValue: "test")) { _, _ in return true }
 		let nestedRoute = Route(route: testRoute)
 		
 		XCTAssert(testRoute.isSuspendable == nestedRoute.isSuspendable)
@@ -127,7 +127,7 @@ class Tests: XCTestCase {
 	}
 	
 	func testNestedAnyRouteInitializerOverrideSuspendable() {
-		let testRoute = Route(identifier: RouteIdentifier(rawValue: "test")) { _, _ in return true }
+		let testRoute = Route<UIViewController>(identifier: RouteIdentifier(rawValue: "test")) { _, _ in return true }
 		let nestedRoute = Route(route: testRoute, isSuspendable: false)
 		
 		XCTAssert(testRoute.isSuspendable != nestedRoute.isSuspendable)
@@ -161,7 +161,7 @@ class Tests: XCTestCase {
     func testRoutablePatternMatching() {
         let exp = expectation(description: "pattern match")
         let id = RouteIdentifier(rawValue: "test")
-        let route = Route(identifier: id) { _, _ in return true }
+        let route = Route<UIViewController>(identifier: id) { _, _ in return true }
         
         switch route {
         case id: exp.fulfill()

--- a/Tests/Tests.swift
+++ b/Tests/Tests.swift
@@ -5,15 +5,15 @@ import XCTest
 class Tests: XCTestCase {
 	
 	func testSuspendingRouteHandlingInInitializers() {
-		let routeController = RouteController(rootViewController: UIViewController())
+		let routeController = RouteController(root: UIViewController())
 		XCTAssertTrue(routeController.isPreparedForRouting)
 		
-		let otherController = RouteController(rootViewController: UIViewController(), ready: false)
+		let otherController = RouteController(root: UIViewController(), ready: false)
 		XCTAssertFalse(otherController.isPreparedForRouting)
 	}
 	
 	func testSuspendingRouteHandlingTemporally() {
-		let routeController = RouteController(rootViewController: UIViewController(), ready: true)
+		let routeController = RouteController(root: UIViewController(), ready: true)
 		XCTAssertTrue(routeController.isPreparedForRouting)
 		
 		routeController.suspendHandlingRoutes()
@@ -30,7 +30,7 @@ class Tests: XCTestCase {
 	}
 	
 	func testClearOfStoredRoutes() {
-		let routeController = RouteController(rootViewController: UIViewController(), ready: false)
+		let routeController = RouteController(root: UIViewController(), ready: false)
 		let testRoute = Route<UIViewController>(identifier: RouteIdentifier(rawValue: "test")) { _, _ in return true }
 		routeController.open(testRoute)
 		XCTAssertNotNil(routeController.storedRoute)
@@ -44,7 +44,7 @@ class Tests: XCTestCase {
 	
 	func testAutomaticExecutionOfStoredRoutes() {
 		let exp = expectation(description: "routeExecution")
-		let routeController = RouteController(rootViewController: UIViewController(), ready: false)
+		let routeController = RouteController(root: UIViewController(), ready: false)
 		let testRoute = Route<UIViewController>(identifier: RouteIdentifier(rawValue: "test")) { _, _ in
 			exp.fulfill()
 			return true
@@ -60,18 +60,18 @@ class Tests: XCTestCase {
 	}
 	
 	func testAutomaticOpeningOfRouteConvertibles() {
-		let routeController = RouteController(rootViewController: UIViewController(), ready: true)
+		let routeController = RouteController(root: UIViewController(), ready: true)
 		XCTAssertTrue(routeController.open(SomeRouteConvertible().route))
 	}
 	
 	func testHandlingOfRouteConvertibleFailure() {
-		let routeController = RouteController(rootViewController: UIViewController(), ready: true)
+		let routeController = RouteController(root: UIViewController(), ready: true)
 		XCTAssertFalse(routeController.open(FailingRouteConvertible().route))
 	}
 	
 	func testRouteActionableDestination() {
 		let exp = expectation(description: "routeExecution")
-		let routeController = RouteController(rootViewController: UIViewController())
+		let routeController = RouteController(root: UIViewController())
 		let testRoute = Route<UIViewController>(identifier: RouteIdentifier(rawValue: "test")) { _, _ in
 			
 			let actionable = ActionableObject()
@@ -121,8 +121,8 @@ class Tests: XCTestCase {
 		
 		XCTAssert(testRoute.isSuspendable == nestedRoute.isSuspendable)
 		
-		let routeA = testRoute.route(fromRootViewController: UIViewController(), options: nil)
-		let routeB = nestedRoute.route(fromRootViewController: UIViewController(), options: nil)
+		let routeA = testRoute.route(fromRoot: UIViewController(), options: nil)
+		let routeB = nestedRoute.route(fromRoot: UIViewController(), options: nil)
 		XCTAssert(routeA == routeB)
 	}
 	


### PR DESCRIPTION
There isn't really any reason that the Root of a route must be a UIViewController. Remove this restriction to allow for more routing patterns (including apps that may use flow controllers or coordinators that are not UIViewControllers)