### PR TITLE
Added Swift Package Manager Support

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -7,4 +7,7 @@ disabled_rules:
 
 identifier_name:
   excluded:
-    - id 
+    - id
+
+excluded:
+  - .build

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,13 @@ env:
     - WORKSPACE=Scotty.xcworkspace
     - IOS_FRAMEWORK_SCHEME=Scotty-iOS
   matrix:
-    - DESTINATION="platform=iOS Simulator,OS=11.2,name=iPhone X"                        SCHEME="$IOS_FRAMEWORK_SCHEME"      RUN_TESTS="YES" POD_LINT="YES"  RUN_DANGER="YES"
+    - DESTINATION="platform=iOS Simulator,OS=11.2,name=iPhone X"                        SCHEME="$IOS_FRAMEWORK_SCHEME"      RUN_TESTS="YES" POD_LINT="YES"  RUN_DANGER="YES" SWIFT_BUILD="YES"
     #- DESTINATION="platform=tvOS Simulator,OS=11.2,name=Apple TV 4K"                    SCHEME="$TVOS_FRAMEWORK_SCHEME"     RUN_TESTS="YES" POD_LINT="NO"  RUN_DANGER="NO"
     #- DESTINATION="platform=watchOS Simulator,OS=4.2,name=Apple Watch Series 3 - 42mm"  SCHEME="$WATCHOS_FRAMEWORK_SCHEME"  RUN_TESTS="NO"  POD_LINT="NO"  RUN_DANGER="NO"
+cache:
+    directories:
+      - ~/.danger-swift
+      - .build
 addons:
   homebrew:
     update: true
@@ -33,6 +37,11 @@ script:
   # Run `pod lib lint` if specified
   - if [ $POD_LINT == "YES" ]; then
       pod lib lint;
+    fi
+    
+  # Run `swift build` if specified
+  - if [ $SWIFT_BUILD == "YES"]; then
+      swift build;
     fi
 
   # Run Danger if specified

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 [#30](https://github.com/BottleRocketStudios/iOS-Scotty/pull/30)
 
 * Added Swift Package Manager support.
-[Brian Miller](https://gitthub.com/jobsismyhomeboy)
+[Brian Miller](https://github.com/jobsismyhomeboy)
 [#28](https://github.com/BottleRocketStudios/iOS-Scotty/issues/28)
 
 ##### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 [Will McGinty](https://github.com/wmcginty)
 [#30](https://github.com/BottleRocketStudios/iOS-Scotty/pull/30)
 
+* Added Swift Package Manager support.
+[Brian Miller](https://gitthub.com/jobsismyhomeboy)
+[#28](https://github.com/BottleRocketStudios/iOS-Scotty/issues/28)
+
 ##### Bug Fixes
 
 * None.

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,22 @@
+// swift-tools-version:5.0
+import PackageDescription
+
+let package = Package(
+    name: "Scotty",
+    platforms: [
+        .iOS("9.0")
+    ],
+    products: [
+        .library(
+            name: "Scotty",
+            targets: ["Scotty"])
+    ],
+    targets: [
+        .target(
+            name: "Scotty",
+            path: "Sources"),
+        .testTarget(
+            name: "ScottyTests",
+            path: "Tests")
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -101,6 +101,14 @@ To run the example project, clone the repo, and run `pod install` from the Examp
 
 ### Installation 
 
+### Swift Package Manager
+
+```swift
+dependencies: [
+    .package(url: "https://github.com/BottleRocketStudios/iOS-Scotty.git", from: "2.1.0")
+]
+```
+
 #### CocoaPods
 
 [CocoaPods]: http://cocoapods.org

--- a/Scotty.xcodeproj/project.pbxproj
+++ b/Scotty.xcodeproj/project.pbxproj
@@ -90,6 +90,7 @@
 		0EFFC4CA2035E7D500BC168B /* Scotty.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Scotty.h; sourceTree = "<group>"; };
 		0EFFC4CB2035E7D500BC168B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		0EFFC4D02035E7D500BC168B /* Scotty-iOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Scotty-iOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		5C5285F22322DB2B00A25962 /* Package.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
 		62F525702257FA6B0052B8E7 /* CHANGELOG.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = CHANGELOG.md; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -197,6 +198,7 @@
 			children = (
 				0EFFC4B92035E63E00BC168B /* README.md */,
 				62F525702257FA6B0052B8E7 /* CHANGELOG.md */,
+				5C5285F22322DB2B00A25962 /* Package.swift */,
 				0EFFC4B72035E62700BC168B /* Sources */,
 				0EFFC4B82035E62E00BC168B /* Tests */,
 				0E2FDC122035E98800E1DE39 /* Examples */,


### PR DESCRIPTION
Added SPM Support and tested against my fork on Xcode 11. Using the `swift build` command to test the build with travis. Addresses Issue #28 