### PR TITLE
Change the way routes are stored for added flexibility on resumption

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,9 +7,9 @@ on:
 
 jobs:
   Build:
-    runs-on: macos-11
+    runs-on: macos-12
     env:
-      DEVELOPER_DIR: /Applications/Xcode_13.2.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_14.2.app/Contents/Developer
       workspace: "Scotty.xcworkspace"
     strategy:
       fail-fast: false
@@ -47,9 +47,9 @@ jobs:
         fi
 
   Lint:
-    runs-on: macos-11
+    runs-on: macos-12
     env:
-      DEVELOPER_DIR: /Applications/Xcode_13.2.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_14.2.app/Contents/Developer
       cocoapods: true
       spm: true
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
 
             - name: "tvOS"
               scheme: "Scotty tvOS"
-              destination: "platform=tvOS Simulator,OS=16.2,name=Apple TV 4K (2nd generation)"
+              destination: "platform=tvOS Simulator,OS=16.1,name=Apple TV 4K (2nd generation)"
               test: true
 
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,12 +18,12 @@ jobs:
         include:
             - name: "iOS"
               scheme: "Scotty iOS"
-              destination: "platform=iOS Simulator,OS=15.2,name=iPhone 12 Pro"
+              destination: "platform=iOS Simulator,OS=16.2,name=iPhone 14 Pro"
               test: true
 
             - name: "tvOS"
               scheme: "Scotty tvOS"
-              destination: "platform=tvOS Simulator,OS=15.2,name=Apple TV 4K (2nd generation)"
+              destination: "platform=tvOS Simulator,OS=16.2,name=Apple TV 4K (2nd generation)"
               test: true
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ##### Enhancements
 
-* None
+* Expand the capabilities of `StoredRoutePolicy` for greater flexibility upon resumption of route handling. 
+[Will McGinty](https://github.com/wmcginty)
+[#44](https://github.com/BottleRocketStudios/iOS-Scotty/pull/44)
+
 
 ##### Bug Fixes
 
@@ -15,7 +18,7 @@
 
 * Expose `isPreparedForRouting` and `isPendingRouteExecution` outside the module.
 [Will McGinty](https://github.com/wmcginty)
-[#36](https://github.com/BottleRocketStudios/iOS-Scotty/issues/36)
+[#36](https://github.com/BottleRocketStudios/iOS-Scotty/pull/36)
 
 ##### Bug Fixes
 

--- a/Sources/Route.swift
+++ b/Sources/Route.swift
@@ -11,7 +11,7 @@ public struct Route<Root> {
     public typealias Navigator = (_ root: Root, _ options: [AnyHashable: Any]?) -> Bool
     
     // MARK: Properties
-    public let navigator: Navigator
+    private let navigator: Navigator
 
     /// Determines if this Routable object can be suspended by its executing RouteController. If this property is set to false, this route will always execute immediately.
     public let isSuspendable: Bool

--- a/Sources/Route.swift
+++ b/Sources/Route.swift
@@ -11,7 +11,7 @@ public struct Route<Root> {
     public typealias Navigator = (_ root: Root, _ options: [AnyHashable: Any]?) -> Bool
     
     // MARK: Properties
-    private let navigator: Navigator
+    public let navigator: Navigator
 
     /// Determines if this Routable object can be suspended by its executing RouteController. If this property is set to false, this route will always execute immediately.
     public let isSuspendable: Bool

--- a/Sources/RouteController.swift
+++ b/Sources/RouteController.swift
@@ -52,14 +52,14 @@ public extension RouteController {
 // MARK: Routing Availability
 public extension RouteController {
 	
-	/// The StoredRoutePolicy determines the outcome of any routes the `RouteController` has stored when it resumes handling routes.
-	enum StoredRoutePolicy {
+    /// The StoredRoutePolicy determines the outcome of any routes the `RouteController` has stored when it resumes handling routes.
+    enum StoredRoutePolicy {
 
         /// The stored route will be executed, and then cleared.
-		case execute
+        case execute
 
         /// The stored route will be cleared. It will not be executed.
-		case clear
+        case clear
 
         ///  Given the `StoredRoute`, return an arbitrary route to execute after resumption of route handling.
         case transform((StoredRoute<Root>) -> Route<Root>?)
@@ -75,17 +75,18 @@ public extension RouteController {
 			case .execute: routeController.executeStoredRoute()
 			case .clear: routeController.clearStoredRoute()
             case .transform(let routeTransformer):
-                if let storedRoute = routeController.storedRoute {
-                    routeController.clearStoredRoute()
-
-                    let pendingRoute = routeTransformer(storedRoute)
-                    routeController.open(pendingRoute)
+                if let stored = routeController.storedRoute {
+                    guard let pendingRoute = routeTransformer(stored) else {
+                        return routeController.clearStoredRoute()
+                    }
+                    
+                    routeController.storedRoute = .init(route: pendingRoute, options: nil)
+                    routeController.executeStoredRoute()
                 }
 
             case .custom(let handler):
                 let storedRoute = routeController.storedRoute
                 routeController.clearStoredRoute()
-
                 handler(storedRoute, routeController)
 
 			default: return

--- a/Sources/RouteController.swift
+++ b/Sources/RouteController.swift
@@ -10,12 +10,18 @@ import Foundation
 /// The RouteController object handles the execution of routes as entry points into your application.
 /// The route controller is generic over its root, meaning that it will only accept routes that begin in the same root type as it was created with.
 open class RouteController<Root>: NSObject {
+
+    // MARK: - RouteController.StoredRoute
+    public struct StoredRoute<Root> {
+        public let route: Route<Root>
+        public let options: [AnyHashable: Any]?
+    }
     
     // MARK: Properties
     public let root: Root
     public private(set) var isPreparedForRouting = false
     public var isPendingRouteExecution: Bool { return storedRoute != nil }
-    private(set) var storedRoute: (() -> Void)?
+    private(set) var storedRoute: StoredRoute<Root>?
     
     // MARK: Initializers
     public init(root: Root, ready: Bool = true) {
@@ -31,14 +37,14 @@ public extension RouteController {
 	
 	/// Attempts to open (and execute) any object that conforms to the Routable protocol, passing in the providing routing options during execution. If routing reaches its intended destination, returns true. Otherwise returns false.
 	///
-	/// - Parameters:
+	/// - Parameters:  
 	///   - routable: The object to be executed.
 	///   - options: Any routing options that should be taken into account when routing.
 	/// - Returns: Returns true if routing reaches its intended destination, otherwise returns false.
     @discardableResult
     func open(_ route: Route<Root>?, options: [AnyHashable: Any]? = nil) -> Bool {
         guard let route = route else { return false }
-        guard isPreparedForRouting || !route.isSuspendable else { storedRoute = stored(route: route, options: options); return false }
+        guard isPreparedForRouting || !route.isSuspendable else { storedRoute = StoredRoute(route: route, options: options); return false }
         return route.route(fromRoot: root, options: options)
     }
 }
@@ -46,22 +52,42 @@ public extension RouteController {
 // MARK: Routing Availability
 public extension RouteController {
 	
-	/// The StoredRoutePolicy determines the outcome of any routes the RouteController has stored when it resumes handling routes.
-	///
-	/// - execute: The stored route will be executed, and then cleared.
-	/// - clear: The stored route will be cleared. It will not be executed.
-	/// - none: The stored route will not be cleared or executed.
+	/// The StoredRoutePolicy determines the outcome of any routes the `RouteController` has stored when it resumes handling routes.
 	enum StoredRoutePolicy {
+
+        /// The stored route will be executed, and then cleared.
 		case execute
+
+        /// The stored route will be cleared. It will not be executed.
 		case clear
-		case none
+
+        ///  Given the `StoredRoute`, return an arbitrary route to execute after resumption of route handling.
+        case transform((StoredRoute<Root>) -> Route<Root>?)
+
+        /// Given the `StoredRoute` and the `RouteController`, perform any action after the resumption of route handling.
+        case custom((StoredRoute<Root>?, RouteController<Root>) -> Void)
+
+        /// The stored route will not be cleared or executed.
+        case none
 		
 		fileprivate func executePolicy(with routeController: RouteController<Root>) {
 			switch self {
-			case .execute:
-				routeController.executeStoredRoute()
-			case .clear:
-				routeController.clearStoredRoute()
+			case .execute: routeController.executeStoredRoute()
+			case .clear: routeController.clearStoredRoute()
+            case .transform(let routeTransformer):
+                if let storedRoute = routeController.storedRoute {
+                    routeController.clearStoredRoute()
+
+                    let pendingRoute = routeTransformer(storedRoute)
+                    routeController.open(pendingRoute)
+                }
+
+            case .custom(let handler):
+                let storedRoute = routeController.storedRoute
+                routeController.clearStoredRoute()
+
+                handler(storedRoute, routeController)
+
 			default: return
 			}
 		}
@@ -93,21 +119,13 @@ public extension RouteController {
 fileprivate extension RouteController {
 	
 	func executeStoredRoute() {
-		storedRoute?()
-		clearStoredRoute()
+        if let storedRoute {
+            open(storedRoute.route, options: storedRoute.options)
+            clearStoredRoute()
+        }
 	}
 	
 	func clearStoredRoute() {
 		storedRoute = nil
 	}
-}
-
-// MARK: Route Storage
-fileprivate extension RouteController {
-    
-    func stored(route: Route<Root>, options: [AnyHashable: Any]?) -> () -> Void {
-        return { [weak self] in
-            self?.open(route, options: options)
-        }
-    }
 }


### PR DESCRIPTION
This shouldn't change the public API in any breaking way (it adds 2 new cases to the non-`@frozen` enum `StoredRoutePolicy`).